### PR TITLE
fix(elastic-service): update elastic search query to exclude adverts

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - feature/**
       - GAP-**
+      - fix/**
     paths-ignore:
       - '*.md'
 
   pull_request:
     types: [closed]
     branches:
+      - fix/**
       - feature/**
       - GAP-**
     paths-ignore:

--- a/src/service/elastic_service.data.js
+++ b/src/service/elastic_service.data.js
@@ -1,4 +1,7 @@
-import { ELASTIC_GRANT_PAGE_FIELDS } from '../utils/constants';
+import {
+  ELASTIC_GRANT_PAGE_FIELDS,
+  ELASTIC_INDEX_FIELDS,
+} from '../utils/constants';
 
 export const elasticSearchResultMinimumAmount = {
   body: {
@@ -9,10 +12,10 @@ export const elasticSearchResultMinimumAmount = {
           {
             multi_match: {
               fields: [
-                'fields.grantName.en-US',
-                'fields.grantSummaryTab.en-US.content.content.*',
-                'fields.grantEligibilityTab.en-US.content.content.*',
-                'fields.grantShortDescription.en-US',
+                ELASTIC_INDEX_FIELDS.grantName,
+                ELASTIC_INDEX_FIELDS.summary,
+                ELASTIC_INDEX_FIELDS.eligibility,
+                ELASTIC_INDEX_FIELDS.shortDescription,
               ],
               fuzziness: 'AUTO',
               operator: 'AND',
@@ -21,19 +24,21 @@ export const elasticSearchResultMinimumAmount = {
           },
         ],
         must: [
-          { match: { 'sys.type': 'Entry' } },
-          { match: { 'sys.contentType.sys.id': 'grantDetails' } },
+          { match: { [ELASTIC_INDEX_FIELDS.type]: 'Entry' } },
+          { match: { [ELASTIC_INDEX_FIELDS.contentType]: 'grantDetails' } },
           {
             range: {
-              'fields.grantApplicationCloseDate.en-US': { gte: 'now/d' },
+              [ELASTIC_INDEX_FIELDS.applicationClosingDate]: {
+                gte: 'now/d',
+              },
             },
           },
         ],
-        must_not: [{ match: { 'sys.publishedCounter': 0 } }],
+        must_not: [{ match: { [ELASTIC_INDEX_FIELDS.publishedCounter]: 0 } }],
       },
     },
     size: 10,
-    sort: [{ 'fields.grantMinimumAward.en-US': { order: 'asc' } }],
+    sort: [{ [ELASTIC_INDEX_FIELDS.grantMinimumAward]: { order: 'asc' } }],
   },
   index: process.env.ELASTIC_INDEX,
   _source: ELASTIC_GRANT_PAGE_FIELDS,
@@ -48,10 +53,10 @@ export const elasticSearchResultMaximumAmount = {
           {
             multi_match: {
               fields: [
-                'fields.grantName.en-US',
-                'fields.grantSummaryTab.en-US.content.content.*',
-                'fields.grantEligibilityTab.en-US.content.content.*',
-                'fields.grantShortDescription.en-US',
+                ELASTIC_INDEX_FIELDS.grantName,
+                ELASTIC_INDEX_FIELDS.summary,
+                ELASTIC_INDEX_FIELDS.eligibility,
+                ELASTIC_INDEX_FIELDS.shortDescription,
               ],
               fuzziness: 'AUTO',
               operator: 'AND',
@@ -60,19 +65,21 @@ export const elasticSearchResultMaximumAmount = {
           },
         ],
         must: [
-          { match: { 'sys.type': 'Entry' } },
-          { match: { 'sys.contentType.sys.id': 'grantDetails' } },
+          { match: { [ELASTIC_INDEX_FIELDS.type]: 'Entry' } },
+          { match: { [ELASTIC_INDEX_FIELDS.contentType]: 'grantDetails' } },
           {
             range: {
-              'fields.grantApplicationCloseDate.en-US': { gte: 'now/d' },
+              [ELASTIC_INDEX_FIELDS.applicationClosingDate]: {
+                gte: 'now/d',
+              },
             },
           },
         ],
-        must_not: [{ match: { 'sys.publishedCounter': 0 } }],
+        must_not: [{ match: { [ELASTIC_INDEX_FIELDS.publishedCounter]: 0 } }],
       },
     },
     size: 10,
-    sort: [{ 'fields.grantMaximumAward.en-US': { order: 'desc' } }],
+    sort: [{ [ELASTIC_INDEX_FIELDS.grantMaximumAward]: { order: 'desc' } }],
   },
   index: process.env.ELASTIC_INDEX,
   _source: ELASTIC_GRANT_PAGE_FIELDS,
@@ -87,10 +94,10 @@ export const elasticSearchResultClosingDate = {
           {
             multi_match: {
               fields: [
-                'fields.grantName.en-US',
-                'fields.grantSummaryTab.en-US.content.content.*',
-                'fields.grantEligibilityTab.en-US.content.content.*',
-                'fields.grantShortDescription.en-US',
+                ELASTIC_INDEX_FIELDS.grantName,
+                ELASTIC_INDEX_FIELDS.summary,
+                ELASTIC_INDEX_FIELDS.eligibility,
+                ELASTIC_INDEX_FIELDS.shortDescription,
               ],
               fuzziness: 'AUTO',
               operator: 'AND',
@@ -99,19 +106,21 @@ export const elasticSearchResultClosingDate = {
           },
         ],
         must: [
-          { match: { 'sys.type': 'Entry' } },
-          { match: { 'sys.contentType.sys.id': 'grantDetails' } },
+          { match: { [ELASTIC_INDEX_FIELDS.type]: 'Entry' } },
+          { match: { [ELASTIC_INDEX_FIELDS.contentType]: 'grantDetails' } },
           {
             range: {
-              'fields.grantApplicationCloseDate.en-US': { gte: 'now/d' },
+              [ELASTIC_INDEX_FIELDS.applicationClosingDate]: {
+                gte: 'now/d',
+              },
             },
           },
         ],
-        must_not: [{ match: { 'sys.publishedCounter': 0 } }],
+        must_not: [{ match: { [ELASTIC_INDEX_FIELDS.publishedCounter]: 0 } }],
       },
     },
     size: 10,
-    sort: [{ 'fields.grantApplicationCloseDate.en-US': { order: 'asc' } }],
+    sort: [{ [ELASTIC_INDEX_FIELDS.applicationClosingDate]: { order: 'asc' } }],
   },
   index: process.env.ELASTIC_INDEX,
   _source: ELASTIC_GRANT_PAGE_FIELDS,
@@ -126,10 +135,10 @@ export const elasticSearchResultWithoutSort = {
           {
             multi_match: {
               fields: [
-                'fields.grantName.en-US',
-                'fields.grantSummaryTab.en-US.content.content.*',
-                'fields.grantEligibilityTab.en-US.content.content.*',
-                'fields.grantShortDescription.en-US',
+                ELASTIC_INDEX_FIELDS.grantName,
+                ELASTIC_INDEX_FIELDS.summary,
+                ELASTIC_INDEX_FIELDS.eligibility,
+                ELASTIC_INDEX_FIELDS.shortDescription,
               ],
               fuzziness: 'AUTO',
               operator: 'AND',
@@ -138,19 +147,23 @@ export const elasticSearchResultWithoutSort = {
           },
         ],
         must: [
-          { match: { 'sys.type': 'Entry' } },
-          { match: { 'sys.contentType.sys.id': 'grantDetails' } },
+          { match: { [ELASTIC_INDEX_FIELDS.type]: 'Entry' } },
+          { match: { [ELASTIC_INDEX_FIELDS.contentType]: 'grantDetails' } },
           {
             range: {
-              'fields.grantApplicationCloseDate.en-US': { gte: 'now/d' },
+              [ELASTIC_INDEX_FIELDS.applicationClosingDate]: {
+                gte: 'now/d',
+              },
             },
           },
         ],
-        must_not: [{ match: { 'sys.publishedCounter': 0 } }],
+        must_not: [{ match: { [ELASTIC_INDEX_FIELDS.publishedCounter]: 0 } }],
       },
     },
     size: 10,
-    sort: [{ 'fields.grantApplicationOpenDate.en-US': { order: 'asc' } }],
+    sort: [
+      { [ELASTIC_INDEX_FIELDS.grantApplicationOpenDate]: { order: 'asc' } },
+    ],
   },
   index: process.env.ELASTIC_INDEX,
   _source: ELASTIC_GRANT_PAGE_FIELDS,

--- a/src/service/elastic_service.data.js
+++ b/src/service/elastic_service.data.js
@@ -23,6 +23,11 @@ export const elasticSearchResultMinimumAmount = {
         must: [
           { match: { 'sys.type': 'Entry' } },
           { match: { 'sys.contentType.sys.id': 'grantDetails' } },
+          {
+            range: {
+              'fields.grantApplicationCloseDate.en-US': { gte: 'now/d' },
+            },
+          },
         ],
         must_not: [{ match: { 'sys.publishedCounter': 0 } }],
       },
@@ -57,6 +62,11 @@ export const elasticSearchResultMaximumAmount = {
         must: [
           { match: { 'sys.type': 'Entry' } },
           { match: { 'sys.contentType.sys.id': 'grantDetails' } },
+          {
+            range: {
+              'fields.grantApplicationCloseDate.en-US': { gte: 'now/d' },
+            },
+          },
         ],
         must_not: [{ match: { 'sys.publishedCounter': 0 } }],
       },
@@ -91,6 +101,11 @@ export const elasticSearchResultClosingDate = {
         must: [
           { match: { 'sys.type': 'Entry' } },
           { match: { 'sys.contentType.sys.id': 'grantDetails' } },
+          {
+            range: {
+              'fields.grantApplicationCloseDate.en-US': { gte: 'now/d' },
+            },
+          },
         ],
         must_not: [{ match: { 'sys.publishedCounter': 0 } }],
       },
@@ -125,6 +140,11 @@ export const elasticSearchResultWithoutSort = {
         must: [
           { match: { 'sys.type': 'Entry' } },
           { match: { 'sys.contentType.sys.id': 'grantDetails' } },
+          {
+            range: {
+              'fields.grantApplicationCloseDate.en-US': { gte: 'now/d' },
+            },
+          },
         ],
         must_not: [{ match: { 'sys.publishedCounter': 0 } }],
       },

--- a/src/service/elastic_service.ts
+++ b/src/service/elastic_service.ts
@@ -155,6 +155,13 @@ export class ElasticSearchService {
             must: [
               { match: { [ELASTIC_INDEX_FIELDS.type]: 'Entry' } },
               { match: { [ELASTIC_INDEX_FIELDS.contentType]: 'grantDetails' } },
+              {
+                range: {
+                  [ELASTIC_INDEX_FIELDS.applicationClosingDate]: {
+                    gte: 'now/d',
+                  },
+                },
+              },
             ],
             must_not: [
               {


### PR DESCRIPTION
### Background

Grants that are being published on Contentful are not being pulled from the Find a grant service. This means grants that have closed are being displayed, and when selected the error page “Page not found” displays. We have 3 grants that should not be displaying on the service.

### Fix

When querying contentful we want to exclude adverts where the closing date is in the past.

Additional fix included adding the new elastic secret to the contentful web hook.

