### PR TITLE
GAP-1950 | fix 500 when we don't have the saved search filter

### DIFF
--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -12,6 +12,7 @@ export const extractFiltersFields = (query, filters) => {
             return true;
           }
         });
+        if (!filter) continue;
         const sublevel = filter.sublevel.filter((sublevel_value) => {
           if (Array.isArray(query[property])) {
             for (const value of query[property]) {


### PR DESCRIPTION
One line change to stop next exploding when we don't have the filter specified in the query string