### PR TITLE
remove grantIdCookieValue and use query param

### DIFF
--- a/__tests__/components/grant-details/grant-details-sidebar.test.js
+++ b/__tests__/components/grant-details/grant-details-sidebar.test.js
@@ -12,7 +12,7 @@ describe('GrantDetailsSidebar component', () => {
     ).toBeDefined();
     expect(link).toBeDefined();
     expect(link.getAttribute('href')).toBe(
-      '/subscriptions/signup?id=test&grantLabel=test',
+      '/subscriptions/signup?grantId=test&grantLabel=test',
     );
   });
 });

--- a/__tests__/pages/notifications/manage-notifications.test.js
+++ b/__tests__/pages/notifications/manage-notifications.test.js
@@ -246,21 +246,12 @@ describe('get server side props for manage notifications page', () => {
       res: {
         setHeader: jest.fn(),
       },
-      req: {
-        cookies: {
-          grantIdCookieValue: '12345678',
-        },
-      },
       query: {
         applyMigrationStatus: 'SUCCEEDED',
         grantId: '12345678',
         action: 'subscribe',
       },
     };
-
-    nookies.get.mockReturnValue({
-      grantIdCookieValue: 'blah',
-    });
 
     fetchByGrantIds.mockReturnValue([]);
 

--- a/__tests__/pages/subscriptions/signup.test.js
+++ b/__tests__/pages/subscriptions/signup.test.js
@@ -184,7 +184,7 @@ describe('getServerSideProps', () => {
   it('should redirect to the 404 page if no grant ID is provided', async () => {
     const request = {
       query: {
-        id: undefined,
+        grantId: undefined,
       },
     };
 
@@ -215,7 +215,7 @@ describe('getServerSideProps', () => {
     process.env.ONE_LOGIN_ENABLED = 'true';
     const request = {
       query: {
-        id: 'a-grant-id',
+        grantId: 'a-grant-id',
         grantLabel: 'a-grant-label',
       },
     };
@@ -247,7 +247,7 @@ describe('getServerSideProps', () => {
 
     const request = {
       query: {
-        id: 'a-grant-id',
+        grantId: 'a-grant-id',
         grantLabel: 'a-grant-label',
         previousFormValues,
         'errors[]': errors,
@@ -277,7 +277,7 @@ describe('getServerSideProps', () => {
 
     const request = {
       query: {
-        id: 'a-grant-id',
+        grantId: 'a-grant-id',
         grantLabel: 'a-grant-label',
         previousFormValues,
         'errors[]': errors,

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,12 +12,6 @@ import {
   addErrorInfo,
 } from './src/utils';
 
-const COOKIE_CONFIG = {
-  path: '/',
-  secure: true,
-  httpOnly: true,
-  maxAge: 900,
-};
 const HOST = process.env.HOST;
 const ONE_LOGIN_ENABLED = process.env.ONE_LOGIN_ENABLED;
 const APPLICANT_HOST = process.env.APPLICANT_HOST;
@@ -75,20 +69,18 @@ const getLoginNoticeUrl = (noticeType: ValueOf<typeof LOGIN_NOTICE_TYPES>) =>
   `${HOST}${notificationRoutes.loginNotice}${noticeType}`;
 
 const handleSubscriptionRedirect = (req: NextRequest) => {
-  const grantId = req.nextUrl.searchParams.get('id');
-
   const res = NextResponse.redirect(
-    getLoginNoticeUrl(LOGIN_NOTICE_TYPES.SUBSCRIPTION_NOTIFICATIONS),
+    `${getLoginNoticeUrl(LOGIN_NOTICE_TYPES.SUBSCRIPTION_NOTIFICATIONS)}${
+      req.nextUrl.search
+    }`,
   );
-
-  res.cookies.set('grantIdCookieValue', grantId, COOKIE_CONFIG);
 
   return res;
 };
 
 const handleSavedSearchRedirect = (req: NextRequest) => {
   const res = NextResponse.redirect(
-    `${getLoginNoticeUrl(LOGIN_NOTICE_TYPES.SAVED_SEARCH)}?${
+    `${getLoginNoticeUrl(LOGIN_NOTICE_TYPES.SAVED_SEARCH)}${
       req.nextUrl.search
     }`,
   );
@@ -149,6 +141,7 @@ const authenticatedPaths = [
   notificationRoutes.manageNotifications,
   notificationRoutes.subscriptionSignUp,
   notificationRoutes.saveSearch,
+  notificationRoutes.deleteSaveSearch,
   newsletterRoutes.signup,
   newsletterRoutes.confirmation,
   newsletterRoutes.unsubscribe,

--- a/pages/login-notice/[type].tsx
+++ b/pages/login-notice/[type].tsx
@@ -44,10 +44,10 @@ export const NOTICE_CONTENT = {
     ],
     redirectUrl: notificationRoutes.manageNotifications,
   }),
-  [SUBSCRIPTION_NOTIFICATIONS]: () => ({
+  [SUBSCRIPTION_NOTIFICATIONS]: (ctx) => ({
     title: 'Sign up for updates',
     content: getNotificationContent('sign up for updates'),
-    redirectUrl: `${notificationRoutes.manageNotifications}?action=${URL_ACTIONS.SUBSCRIBE}`,
+    redirectUrl: `${notificationRoutes.manageNotifications}?action=${URL_ACTIONS.SUBSCRIBE}&grantId=${ctx.query.grantId}`,
   }),
   [SAVED_SEARCH]: (ctx) => ({
     title: 'Save your search',
@@ -62,36 +62,26 @@ export const NOTICE_CONTENT = {
 export const getServerSideProps = (ctx: GetServerSidePropsContext) => {
   const { title, content, redirectUrl } =
     NOTICE_CONTENT[ctx.params?.type as string](ctx);
+  console.log({ ctx });
   return {
     props: {
       title,
       content,
       redirectUrl,
-      type: ctx.params?.type,
       userServiceHost: USER_SERVICE_HOST,
       host: HOST,
     },
   };
 };
 
-const getRedirectUrlQueryString = (type: string) =>
-  `?migrationType=${type}${
-    type === SUBSCRIPTION_NOTIFICATIONS
-      ? `&action=${URL_ACTIONS.SUBSCRIBE}`
-      : ''
-  }`;
-
 const LoginNotice = ({
   title,
   content,
   redirectUrl,
-  type,
   host,
   userServiceHost,
 }) => {
-  const formattedRedirectUrl = encodeURIComponent(
-    `${host}${redirectUrl}${getRedirectUrlQueryString(type)}`,
-  );
+  const formattedRedirectUrl = encodeURIComponent(`${host}${redirectUrl}`);
   return (
     <>
       <Head>

--- a/pages/notifications/manage-notifications/index.tsx
+++ b/pages/notifications/manage-notifications/index.tsx
@@ -198,12 +198,11 @@ const buildSavedSearch = async (query, jwtPayload) => {
 
 const saveNotificationIfPresent = async ({
   action,
-  grantIdCookieValue,
   grantId,
   jwtPayload,
   ctx,
 }) => {
-  if (action === URL_ACTIONS.SUBSCRIBE && grantIdCookieValue) {
+  if (action === URL_ACTIONS.SUBSCRIBE && grantId) {
     await SubscriptionService.getInstance().addSubscription({
       emailAddress: jwtPayload.email,
       sub: jwtPayload.sub,
@@ -254,7 +253,7 @@ export const getServerSideProps: GetServerSideProps<
   const plainTextEmailAddress = await getEmail(ctx);
   const userId = await getUserId(ctx);
 
-  let grantId = ctx.query.grantId;
+  const grantId = ctx.query.grantId;
   let jwtValue: string,
     migrationBannerProps: MigrationBannerProps = {
       applyMigrationStatus: null,
@@ -265,17 +264,9 @@ export const getServerSideProps: GetServerSideProps<
   if (process.env.ONE_LOGIN_ENABLED === 'true') {
     const { jwtPayload, jwt } = getJwtFromCookies(ctx.req);
     jwtValue = jwt;
-    const { grantIdCookieValue } = ctx.req.cookies;
-    ctx.res.setHeader(
-      'Set-Cookie',
-      `${cookieName.grantId}=deleted; Path=/; Max-Age=0`,
-    );
-
-    grantId = grantIdCookieValue || grantId;
 
     const redirect = await saveNotificationIfPresent({
       action,
-      grantIdCookieValue,
       grantId,
       jwtPayload,
       ctx,

--- a/pages/subscriptions/confirmation.js
+++ b/pages/subscriptions/confirmation.js
@@ -30,7 +30,7 @@ export async function getServerSideProps({ req }) {
   if (validationErrors.length > 0) {
     const errorParam = generateSignupErrorsRedirectParam(validationErrors);
     const previousFormValues = getPreviousFormValues(body);
-    const redirectPath = `/subscriptions/signup?id=${body.grantLabel}${errorParam}&${previousFormValues}`;
+    const redirectPath = `/subscriptions/signup?grantId=${body.grantLabel}${errorParam}&${previousFormValues}`;
     return {
       redirect: {
         permanemt: false,

--- a/pages/subscriptions/signup.js
+++ b/pages/subscriptions/signup.js
@@ -15,7 +15,7 @@ export async function getServerSideProps(ctx) {
     const response = await axios.post(
       new URL(`${process.env.HOST}/api/subscription`).toString(),
       {
-        contentfulGrantSubscriptionId: ctx.query.id,
+        contentfulGrantSubscriptionId: ctx.query.grantId,
         emailAddress: jwtPayload.email,
         sub: jwtPayload.sub,
       },
@@ -33,7 +33,7 @@ export async function getServerSideProps(ctx) {
     return {
       redirect: {
         permanent: false,
-        destination: `${notificationRoutes['manageNotifications']}?action=${URL_ACTIONS.SUBSCRIBE}&grantId=${ctx.query.id}`,
+        destination: `${notificationRoutes['manageNotifications']}?action=${URL_ACTIONS.SUBSCRIBE}&grantId=${ctx.query.grantId}`,
       },
     };
   }

--- a/src/components/grant-details-page/grant-details-sidebar/GrantDetailsSidebar.js
+++ b/src/components/grant-details-page/grant-details-sidebar/GrantDetailsSidebar.js
@@ -4,7 +4,7 @@ export function GrantDetailsSidebar({ grantLabel, grantId }) {
       <hr className="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-2 govuk-border-colour"></hr>
       <h2 className="govuk-heading-m">Get updates about this grant</h2>
       <a
-        href={`/subscriptions/signup?id=${grantId}&grantLabel=${grantLabel}`}
+        href={`/subscriptions/signup?grantId=${grantId}&grantLabel=${grantLabel}`}
         className="govuk-link"
         data-cy="cySignupUpdatesLink"
       >

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -7,7 +7,6 @@ export type UnsubscribeSubscriptionRequest = {
 
 export type MigrationBannerProps = {
   applyMigrationStatus: string | null;
-  grantIdCookieValue?: string | null;
   findMigrationStatus: string | null;
   migrationType: string | null;
 };


### PR DESCRIPTION
## Description

[Ticket # and link](https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2277)

Stops the app "exploding" by stripping out `grantIdCookieValue` entirely and relying on query parameters to pass this information around. Manage notifications no longer blows up on refresh as the info is stored in the URL.

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
