### PR TITLE
fix remaining pages in dev

### DIFF
--- a/__tests__/pages/subscriptions/signup.test.js
+++ b/__tests__/pages/subscriptions/signup.test.js
@@ -3,7 +3,7 @@ import Signup, {
   getServerSideProps,
 } from '../../../pages/subscriptions/signup';
 import { fetchEntry } from '../../../src/utils/contentFulPage';
-import { client } from '../../../src/utils';
+import { client } from '../../../src/utils/axios';
 
 jest.mock('../../../src/utils/contentFulPage');
 jest.mock('next/router', () => ({

--- a/pages/api/newsletter-signup/[token].test.js
+++ b/pages/api/newsletter-signup/[token].test.js
@@ -2,7 +2,7 @@ import handler from './[token]';
 import { decryptSignedApiKey } from '../../../src/service/api-key-service';
 import { notificationRoutes, URL_ACTIONS } from '../../../src/utils/constants';
 import { encrypt } from '../../../src/utils/encryption';
-import { client } from '../../../src/utils';
+import { client } from '../../../src/utils/axios';
 
 jest.mock('../../../src/utils/axios', () => ({
   client: {

--- a/pages/api/newsletter-signup/[token].ts
+++ b/pages/api/newsletter-signup/[token].ts
@@ -4,7 +4,8 @@ import {
   generateSignedApiKey,
 } from '../../../src/service/api-key-service';
 import { NewsletterSubscription } from '../../../src/types/newsletter';
-import { addErrorInfo, client as axios, logger } from '../../../src/utils';
+import { addErrorInfo, logger } from '../../../src/utils';
+import { client as axios } from '../../../src/utils/axios';
 import nookies from 'nookies';
 import {
   cookieName,

--- a/pages/api/subscription/index.ts
+++ b/pages/api/subscription/index.ts
@@ -1,4 +1,4 @@
-import { axios } from '../../../src/utils';
+import { axios } from '../../../src/utils/axios';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 type CreateNewSubscriptionBody = {

--- a/pages/notifications/delete-saved-search/[slug].js
+++ b/pages/notifications/delete-saved-search/[slug].js
@@ -15,7 +15,8 @@ import {
 import { decrypt } from '../../../src/utils/encryption';
 import { decryptSignedApiKey } from '../../../src/service/api-key-service';
 import cookieExistsAndContainsValidJwt from '../../../src/utils/cookieAndJwtChecker';
-import { axios, getJwtFromCookies } from '../../../src/utils';
+import { getJwtFromCookies } from '../../../src/utils';
+import { axios } from '../../../src/utils/axios';
 
 const breadcrumbsRoutes = [
   {

--- a/pages/subscriptions/signup.js
+++ b/pages/subscriptions/signup.js
@@ -6,7 +6,7 @@ import gloss from '../../src/utils/glossary.json';
 import { getJwtFromCookies } from '../../src/utils/jwt';
 import { URL_ACTIONS, notificationRoutes } from '../../src/utils/constants';
 import { fetchGrantDetail } from '../../src/utils/grantDetails';
-import { client as axios } from '../../src/utils';
+import { client as axios } from '../../src/utils/axios';
 
 export async function getServerSideProps(ctx) {
   if (process.env.ONE_LOGIN_ENABLED === 'true') {

--- a/src/service/newsletter/newsletter-subscription-service.ts
+++ b/src/service/newsletter/newsletter-subscription-service.ts
@@ -1,4 +1,5 @@
-import { axios, axiosConfig } from '../../../src/utils';
+import { axios } from '../../../src/utils/axios';
+import { axiosConfig } from '../../utils';
 import { NewsletterSubscription, NewsletterType } from '../../types/newsletter';
 
 export class NewsletterSubscriptionService {

--- a/src/service/saved_search_service.test.js
+++ b/src/service/saved_search_service.test.js
@@ -6,7 +6,7 @@ import {
   updateStatus,
   deleteSaveSearch,
 } from './saved_search_service';
-import { axios } from '../../src/utils';
+import { axios } from '../../src/utils/axios';
 
 jest.mock('../../src/utils/axios', () => ({
   axios: jest.fn(),

--- a/src/service/saved_search_service.ts
+++ b/src/service/saved_search_service.ts
@@ -1,4 +1,5 @@
-import { axios, axiosConfig } from '../../src/utils';
+import { axiosConfig } from '../../src/utils';
+import { axios } from '../../src/utils/axios';
 
 //TODO remove these ESLint exceptions and fix
 export enum SavedSearchStatusType {

--- a/src/service/subscription-service.ts
+++ b/src/service/subscription-service.ts
@@ -1,4 +1,5 @@
-import { axios, axiosConfig } from '../../src/utils';
+import { axiosConfig } from '../../src/utils';
+import { axios } from '../../src/utils/axios';
 import { UnsubscribeSubscriptionRequest } from '../types/subscription';
 
 export class SubscriptionService {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,2 @@
-export * from './axios';
 export * from './jwt';
 export * from './logger';


### PR DESCRIPTION
## Description

Nextjs doesn't configure webpack to tree shake during dev, so (re)exporting `axios` (without explicitly configuring it for use in a browser) from the barrel file in `utils` results in client-side errors when running the app in dev mode. This PR removes `axios` from the barrel file, fixing the site when run in dev mode.

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
