### PR TITLE
Remove timestamp from opening and closing date

### DIFF
--- a/__tests__/components/grant-details/grant-details-header.test.js
+++ b/__tests__/components/grant-details/grant-details-header.test.js
@@ -21,8 +21,8 @@ describe('GrantDetailsHeader component', () => {
   });
 
   it('should render an opening and closing date on the screen', () => {
-    expect(screen.getByText('7 April 2022, 9:34am')).toBeDefined();
-    expect(screen.getByText('15 April 2022, 9:34am')).toBeDefined();
+    expect(screen.getByText('7 April 2022')).toBeDefined();
+    expect(screen.getByText('15 April 2022')).toBeDefined();
   });
 
   it('should render the values from glossary.json for the opening and closing dates', () => {

--- a/__tests__/pages/grant-page.test.js
+++ b/__tests__/pages/grant-page.test.js
@@ -179,7 +179,7 @@ describe('Rendering the browse grants page', () => {
         );
       }),
     ).toBeDefined();
-    expect(screen.getByText('3 February 2022, 12:01am')).toBeDefined();
+    expect(screen.getByText('3 February 2022')).toBeDefined();
   });
 
   it('Should render grant closing date', () => {
@@ -191,7 +191,7 @@ describe('Rendering the browse grants page', () => {
         );
       }),
     ).toBeDefined();
-    expect(screen.getByText('3 April 2022, 12:01am')).toBeDefined();
+    expect(screen.getByText('3 April 2022')).toBeDefined();
   });
 
   it('Should render a label for the search form', () => {

--- a/src/components/grant-details-page/grant-details-header/GrantDetailsHeader.js
+++ b/src/components/grant-details-page/grant-details-header/GrantDetailsHeader.js
@@ -19,7 +19,7 @@ export function GrantDetailsHeader({ grant }) {
         <li>
           <strong>{gloss.grantDetails.opens}:</strong>{' '}
           <span>
-            <Moment format="D MMMM YYYY, h:mma" tz="GMT">
+            <Moment format="D MMMM YYYY" tz="GMT">
               {moment.utc(grant.grantApplicationOpenDate)}
             </Moment>
           </span>
@@ -27,7 +27,7 @@ export function GrantDetailsHeader({ grant }) {
         <li>
           <strong>{gloss.grantDetails.closes}:</strong>{' '}
           <span>
-            <Moment format="D MMMM YYYY, h:mma" tz="GMT">
+            <Moment format="D MMMM YYYY" tz="GMT">
               {moment.utc(grant.grantApplicationCloseDate)}
             </Moment>
           </span>


### PR DESCRIPTION
As the times are hardcoded to 12:01am and 11:59pm this does not necessarily match the opening and closing times specified by the fund which may cause user confusion
CC @jgunnCO @john-tco 

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [x] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
