### PR TITLE
hide unpublished or deleted grants on /manage-notifications

### DIFF
--- a/__tests__/pages/notifications/manage-notifications.test.js
+++ b/__tests__/pages/notifications/manage-notifications.test.js
@@ -227,7 +227,7 @@ describe('get server side props for manage notifications page', () => {
       )
       .mockImplementation(() => newsletterSubscription);
 
-    fetchByGrantIds.mockReturnValue([]);
+    fetchByGrantIds.mockReturnValue(testGrants);
     const result = await management.getServerSideProps(context);
 
     expect(decrypt).toHaveBeenCalledTimes(2);
@@ -253,7 +253,7 @@ describe('get server side props for manage notifications page', () => {
       },
     };
 
-    fetchByGrantIds.mockReturnValue([]);
+    fetchByGrantIds.mockReturnValue(testGrants);
 
     const subscriptionServiceMock = jest
       .spyOn(SubscriptionService.prototype, 'getSubscriptionsByEmail')

--- a/pages/notifications/manage-notifications/index.tsx
+++ b/pages/notifications/manage-notifications/index.tsx
@@ -113,17 +113,21 @@ const mergeGrantNameIntoSubscriptions = async (subscriptions) => {
     ),
   );
 
-  return subscriptions.map((subscription) => {
-    const foundGrant = subscribedGrants.find(
-      (grant) => subscription.contentfulGrantSubscriptionId === grant.sys.id,
-    );
+  return subscriptions
+    .map((subscription) => {
+      const foundGrant = subscribedGrants.find(
+        (grant) => subscription.contentfulGrantSubscriptionId === grant.sys.id,
+      );
+      console.log({ foundGrant });
+      if (foundGrant) {
+        subscription.grantName = foundGrant.fields.grantName;
+        return subscription;
+      }
 
-    if (foundGrant) {
-      subscription.grantName = foundGrant.fields.grantName;
-    }
-
-    return subscription;
-  });
+      // if we don't have a grant for this subscription, hide it - the grant is unpublished
+      return null;
+    })
+    .filter((subscription) => !!subscription);
 };
 
 const sortGrantSubscriptions = (a, b) =>

--- a/pages/notifications/manage-notifications/index.tsx
+++ b/pages/notifications/manage-notifications/index.tsx
@@ -118,7 +118,7 @@ const mergeGrantNameIntoSubscriptions = async (subscriptions) => {
       const foundGrant = subscribedGrants.find(
         (grant) => subscription.contentfulGrantSubscriptionId === grant.sys.id,
       );
-      console.log({ foundGrant });
+
       if (foundGrant) {
         subscription.grantName = foundGrant.fields.grantName;
         return subscription;


### PR DESCRIPTION
## Description

Fix for https://technologyprogramme.atlassian.net/jira/software/projects/GAP/boards/216?selectedIssue=GAP-2285

As per the comment on the issue, we're hiding unpublished or closed grants on the `/manage-notifications` page - while it would technically still be possible to unsubscribe, without the name of the grant the user would have no way of knowing what they were unsubscribing from.

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
