### PR TITLE
pre-render correct newsletter link when one login enabled

### DIFF
--- a/src/components/newsletter/NewsletterCallToAction.tsx
+++ b/src/components/newsletter/NewsletterCallToAction.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { BellIcon } from '../icons/BellIcon/BellIcon';
 import styles from './NewsletterCallToAction.module.css';
-import { useAppContext } from '../../../pages/_app';
+import { useAppContext, useAuth } from '../../../pages/_app';
 import {
   LOGIN_NOTICE_TYPES,
   URL_ACTIONS,
@@ -12,20 +12,34 @@ type NewsletterCTAProps = {
   returnParams: URLSearchParams;
 };
 
-const getNewsletterPath = (oneLoginEnabled, returnParams) => {
-  if (oneLoginEnabled)
-    return {
-      pathname: notificationRoutes.manageNotifications,
-      query: {
-        action: URL_ACTIONS.NEWSLETTER_SUBSCRIBE,
-        migrationType: LOGIN_NOTICE_TYPES.NEWSLETTER,
-      },
-    };
+const getNewsletterPath = ({
+  oneLoginEnabled,
+  isUserLoggedIn,
+  returnParams,
+}) => {
+  if (oneLoginEnabled) {
+    if (!isUserLoggedIn)
+      return {
+        pathname: notificationRoutes.loginNotice,
+        query: {
+          action: URL_ACTIONS.SUBSCRIBE,
+          migrationType: LOGIN_NOTICE_TYPES.NEWSLETTER,
+        },
+      };
+    else
+      return {
+        pathname: notificationRoutes.manageNotifications,
+        query: {
+          action: URL_ACTIONS.NEWSLETTER_SUBSCRIBE,
+        },
+      };
+  }
   return { pathname: '/newsletter', query: returnParams };
 };
 
 const NewsletterCallToAction = ({ returnParams }: NewsletterCTAProps) => {
   const { oneLoginEnabled } = useAppContext();
+  const { isUserLoggedIn } = useAuth();
   return (
     <div className={`govuk-grid-row ${styles.withBorder}`}>
       <div className="govuk-grid-column-full gap-search-area govuk-!-padding-4">
@@ -34,7 +48,13 @@ const NewsletterCallToAction = ({ returnParams }: NewsletterCTAProps) => {
           <h3 className={`govuk-heading-s ${styles.newsletterCtaTitle}`}>
             Get updates about new grants
           </h3>
-          <Link href={getNewsletterPath(oneLoginEnabled, returnParams)}>
+          <Link
+            href={getNewsletterPath({
+              oneLoginEnabled,
+              isUserLoggedIn,
+              returnParams,
+            })}
+          >
             <a
               className={`govuk-link govuk-link--no-visited-state govuk-!-font-size-19`}
               data-cy="cySignUpNewsletter"


### PR DESCRIPTION
## Description

https://technologyprogramme.atlassian.net/browse/GAP-2287

Pre-renders correct newsletter link based on user login state, which should prevent odd link pre-rendering behaviour in deployed envs. (This issue doesn't replicate locally which is why I'm saying 'should' here).

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
