### PR TITLE
Adds delete user endpoint by sub or email

### DIFF
--- a/pages/api/user/delete.test.js
+++ b/pages/api/user/delete.test.js
@@ -1,0 +1,98 @@
+import handler from './delete';
+import axios from 'axios';
+
+jest.mock('axios');
+
+describe('handler', () => {
+  it('should make request to backend host and successfully delete a user by sub', async () => {
+    const axiosResponse = { status: 200 };
+
+    axios.mockResolvedValue(axiosResponse);
+
+    const req = {
+      query: {
+        sub: 'urn:fdc:gov.uk:2022:ibd2rz2CgyidndXyq2zyfcnQwyYI57h34TyuGt87Uhs',
+      },
+    };
+
+    const res = {
+      status: jest.fn(() => res),
+      json: jest.fn(() => res),
+    };
+
+    await handler(req, res);
+
+    expect(axios).toHaveBeenCalledWith({
+      method: 'delete',
+      url: `${process.env.BACKEND_HOST}/user/delete`,
+      params: {
+        sub: 'urn:fdc:gov.uk:2022:ibd2rz2CgyidndXyq2zyfcnQwyYI57h34TyuGt87Uhs',
+      },
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should make request to backend host and successfully delete a user by email', async () => {
+    const axiosResponse = { status: 200 };
+
+    axios.mockResolvedValue(axiosResponse);
+
+    const req = {
+      query: {
+        email: 'test-user@email.com',
+      },
+    };
+
+    const res = {
+      status: jest.fn(() => res),
+      json: jest.fn(() => res),
+    };
+
+    await handler(req, res);
+
+    expect(axios).toHaveBeenCalledWith({
+      method: 'delete',
+      url: `${process.env.BACKEND_HOST}/user/delete`,
+      params: {
+        email: 'test-user@email.com',
+      },
+    });
+
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('should make request to backend host and unsuccessfully delete a user', async () => {
+    const axiosError = new Error('Simulated Axios Error');
+    axiosError.response = {
+      status: 500,
+      data: { message: 'User Unsuccessfully deleted' },
+    };
+
+    axios.mockRejectedValue(axiosError);
+
+    const req = {
+      query: {
+        email: 'test-user@gov.uk',
+      },
+    };
+
+    const res = {
+      status: jest.fn(() => res),
+      json: jest.fn(() => res),
+    };
+
+    await handler(req, res);
+
+    expect(axios).toHaveBeenCalledWith({
+      method: 'delete',
+      url: `${process.env.BACKEND_HOST}/user/delete`,
+      params: {
+        email: 'test-user@gov.uk',
+      },
+    });
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(axiosError.response.data);
+  });
+});

--- a/pages/api/user/delete.ts
+++ b/pages/api/user/delete.ts
@@ -1,0 +1,35 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import axios from 'axios';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    const queryParams: { [key: string]: string } = {};
+    if (req.query?.sub) {
+      queryParams.sub = req.query.sub as string;
+    }
+    if (req.query?.email) {
+      queryParams.email = req.query.email as string;
+    }
+
+    const response = await axios({
+      method: 'delete',
+      url: `${process.env.BACKEND_HOST}/user/delete`,
+      params: queryParams,
+    });
+
+    res.status(200).json(response.data);
+  } catch (error) {
+    console.error(`Error deleting user ${req.query} :`, error.message);
+
+    if (error.response) {
+      res.status(error.response.status).json(error.response.data);
+    } else {
+      res.status(500).json({
+        error,
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Description

This ticket adds:

- new delete user endpoint which calls the backend to perform the delete action
 
Ticket # and link

linked PRs:

[Adds delete function by sub and email by dylanwrightCO · Pull Request #76 · cabinetoffice/gap-find-backend](https://github.com/cabinetoffice/gap-find-backend/pull/76) 

[Adds call to delete find user by sub or email by dylanwrightCO · Pull Request #154 · cabinetoffice/gap-user-service](https://github.com/cabinetoffice/gap-user-service/pull/154)

https://technologyprogramme.atlassian.net/browse/GAP-2306

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

full screen recording on ticket

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
