### PR TITLE
GAP-2381 - Removing whitespace from page footers

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -11,6 +11,7 @@ $govuk-new-link-styles: true;
 
 html,
 body {
+  background-color: #f3f2f1;
   margin: 0;
   font-family: 'GDS Transport', arial, sans-serif;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Description

https://technologyprogramme.atlassian.net/browse/GAP-2381

Whitespace was visible beneath footer on pages where there isn't enough content to fill the browser window - have copied the DVLA's solution of making the HTML document itself the same colour as the footer to fill in the gap.

## Type of change

Please check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
