### PR TITLE
Removing babel so we use the faster SWC

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["next/babel"]
-}


### PR DESCRIPTION
Previously the builds log this message: 

`info  - Disabled SWC as replacement for Babel because of custom Babel configuration ".babelrc" https://nextjs.org/docs/messages/swc-disabled`

We have no reason as far as I know to use babel over SWC, and SWC should result in faster builds etc