### PR TITLE
TMI2-550: Automatically close filters on mobile view

### DIFF
--- a/src/components/search-page/search-filter-container/SearchFilterContainer.js
+++ b/src/components/search-page/search-filter-container/SearchFilterContainer.js
@@ -13,11 +13,6 @@ export function SearchFilterContainer({ filters, filterObj, query }) {
     );
     if ($filterAccordion && window.GOVUKFrontend !== undefined) {
       new window.GOVUKFrontend.Accordion($filterAccordion).init();
-
-      // TODO: Backup option
-      // if (isMobile) {
-      //   document.querySelector('.govuk-accordion__controls').click();
-      // }
     }
   }, []);
 
@@ -95,8 +90,8 @@ function SearchOptionsContainer({ filters, filterObj }) {
               <h2 className="govuk-accordion__section-heading govuk-fieldset__heading">
                 <span
                   className="govuk-accordion__section-button"
-                  id={`accordion-default-heading-${index + 1}`}
-                  data-cy={`cyAccordionButton-${''}`}
+                  id={`accordion-default-heading-0`}
+                  data-cy={`cyAccordionButton-${'cyAccordionButton-mobile'}`}
                 >
                   Search options
                 </span>
@@ -104,12 +99,12 @@ function SearchOptionsContainer({ filters, filterObj }) {
             </div>
           </legend>
           <div
-            id={`accordion-default-content-${index + 1}`}
+            id={`accordion-default-content-0`}
             className="govuk-accordion__section-content"
             data-testid="section-content"
-            aria-labelledby={`accordion-default-heading-${index + 1}`}
+            aria-labelledby={`accordion-default-heading-0`}
             role="group"
-            data-cy={`cyAccordionContent-${''}`}
+            data-cy={`cyAccordionContent-${'cyAccordionContent-mobile'}`}
           >
             <Filters filters={filters} filterObj={filterObj} />
           </div>

--- a/src/components/search-page/search-filter-container/SearchFilterContainer.js
+++ b/src/components/search-page/search-filter-container/SearchFilterContainer.js
@@ -4,6 +4,7 @@ import { SearchFilterClearButton } from '../search-clear-filters/SearchFilterCle
 import { SearchFilterDate } from '../search-filter-date/SearchFilterDate';
 import { SearchFilterSelector } from '../search-filter-selector/SearchFilterSelector';
 import { buildQueryString } from '../../../../pages/save-search';
+import { isMobile } from 'react-device-detect';
 
 export function SearchFilterContainer({ filters, filterObj, query }) {
   useEffect(() => {
@@ -12,9 +13,21 @@ export function SearchFilterContainer({ filters, filterObj, query }) {
     );
     if ($filterAccordion && window.GOVUKFrontend !== undefined) {
       new window.GOVUKFrontend.Accordion($filterAccordion).init();
+      // TODO: Backup option
+      // if (isMobile) {
+      //   document.querySelector('.govuk-accordion__controls').click();
+      // }
     }
   }, []);
 
+  return isMobile ? (
+    <MobileContainer filters={filters} filterObj={filterObj} query={query} />
+  ) : (
+    <BaseContainer filters={filters} filterObj={filterObj} query={query} />
+  );
+}
+
+function BaseContainer({ filters, filterObj, query }) {
   return (
     <div className="govuk-grid-column-one-third">
       <div className="gap_filters govuk-!-margin-bottom-2">
@@ -77,5 +90,14 @@ export function SearchFilterContainer({ filters, filterObj, query }) {
         Saving your search will make it quicker to find relevant grants.
       </p>
     </div>
+  );
+}
+
+function MobileContainer({ filters, filterObj, query }) {
+  return (
+    // TODO: Add the collapsable container here
+    <p>
+      <BaseContainer filters={filters} filterObj={filterObj} query={query} />
+    </p>
   );
 }

--- a/src/components/search-page/search-filter-container/SearchFilterContainer.js
+++ b/src/components/search-page/search-filter-container/SearchFilterContainer.js
@@ -8,6 +8,9 @@ import { isMobile } from 'react-device-detect';
 
 export function SearchFilterContainer({ filters, filterObj, query }) {
   useEffect(() => {
+    if (isMobile) {
+      window.sessionStorage.setItem('accordion-default-content-1', 'false');
+    }
     const $filterAccordion = document.querySelector(
       '[data-module="gap-accordion"]',
     );
@@ -33,12 +36,44 @@ export function SearchFilterContainer({ filters, filterObj, query }) {
           aria-label="filter options"
         >
           {isMobile ? (
-            <SearchOptionsContainer filters={filters} filterObj={filterObj} />
+            <MobileSearchOptionsContainer
+              filters={filters}
+              filterObj={filterObj}
+              query={query}
+            />
           ) : (
-            <Filters filters={filters} filterObj={filterObj} />
+            <>
+              <Filters filters={filters} filterObj={filterObj} query={query} />
+            </>
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function Filters({ filters, filterObj, query }) {
+  return (
+    <>
+      {filters?.map((filter, index) => (
+        <SearchFilterSelector
+          key={index}
+          index={index}
+          filter={filter}
+          filterObj={filterObj}
+        />
+      ))}
+
+      <SearchFilterDate index={filters.length} filterObj={filterObj} />
+      <SearchButtons filterObj={filterObj} query={query} />
+    </>
+  );
+}
+
+function SearchButtons({ filterObj, query }) {
+  return (
+    <>
+      {' '}
       <div className="govuk-button-group govuk-!-margin-bottom-0 gap_filters-actions">
         <SearchFilterButton />
 
@@ -68,16 +103,15 @@ export function SearchFilterContainer({ filters, filterObj, query }) {
           Save this search
         </a>
       )}
-
       <p className="govuk-body">
         Saving your search will make it quicker to find relevant grants.
       </p>
-    </div>
+    </>
   );
 }
 
-function SearchOptionsContainer({ filters, filterObj }) {
-  const index = -1;
+function MobileSearchOptionsContainer({ filters, filterObj }) {
+  const index = filters;
   return (
     <div key={index} className="govuk-accordion__section">
       <div
@@ -99,7 +133,7 @@ function SearchOptionsContainer({ filters, filterObj }) {
             </div>
           </legend>
           <div
-            id={`accordion-default-content-0`}
+            id={`mobile-accordion-content`}
             className="govuk-accordion__section-content"
             data-testid="section-content"
             aria-labelledby={`accordion-default-heading-0`}
@@ -111,22 +145,5 @@ function SearchOptionsContainer({ filters, filterObj }) {
         </fieldset>
       </div>
     </div>
-  );
-}
-
-function Filters({ filters, filterObj }) {
-  return (
-    <>
-      {filters?.map((filter, index) => (
-        <SearchFilterSelector
-          key={index}
-          index={index}
-          filter={filter}
-          filterObj={filterObj}
-        />
-      ))}
-
-      <SearchFilterDate index={filters.length} filterObj={filterObj} />
-    </>
   );
 }

--- a/src/components/search-page/search-filter-container/SearchFilterContainer.js
+++ b/src/components/search-page/search-filter-container/SearchFilterContainer.js
@@ -13,6 +13,7 @@ export function SearchFilterContainer({ filters, filterObj, query }) {
     );
     if ($filterAccordion && window.GOVUKFrontend !== undefined) {
       new window.GOVUKFrontend.Accordion($filterAccordion).init();
+
       // TODO: Backup option
       // if (isMobile) {
       //   document.querySelector('.govuk-accordion__controls').click();
@@ -20,14 +21,6 @@ export function SearchFilterContainer({ filters, filterObj, query }) {
     }
   }, []);
 
-  return isMobile ? (
-    <MobileContainer filters={filters} filterObj={filterObj} query={query} />
-  ) : (
-    <BaseContainer filters={filters} filterObj={filterObj} query={query} />
-  );
-}
-
-function BaseContainer({ filters, filterObj, query }) {
   return (
     <div className="govuk-grid-column-one-third">
       <div className="gap_filters govuk-!-margin-bottom-2">
@@ -44,16 +37,11 @@ function BaseContainer({ filters, filterObj, query }) {
           id="accordion-default"
           aria-label="filter options"
         >
-          {filters?.map((filter, index) => (
-            <SearchFilterSelector
-              key={index}
-              index={index}
-              filter={filter}
-              filterObj={filterObj}
-            />
-          ))}
-
-          <SearchFilterDate index={filters.length} filterObj={filterObj} />
+          {isMobile ? (
+            <SearchOptionsContainer filters={filters} filterObj={filterObj} />
+          ) : (
+            <Filters filters={filters} filterObj={filterObj} />
+          )}
         </div>
       </div>
       <div className="govuk-button-group govuk-!-margin-bottom-0 gap_filters-actions">
@@ -93,11 +81,57 @@ function BaseContainer({ filters, filterObj, query }) {
   );
 }
 
-function MobileContainer({ filters, filterObj, query }) {
+function SearchOptionsContainer({ filters, filterObj }) {
+  const index = -1;
   return (
-    // TODO: Add the collapsable container here
-    <p>
-      <BaseContainer filters={filters} filterObj={filterObj} query={query} />
-    </p>
+    <div key={index} className="govuk-accordion__section">
+      <div
+        key={index}
+        className="govuk-accordion__section govuk-accordion__section--expanded"
+      >
+        <fieldset className="govuk-fieldset">
+          <legend className="govuk-fieldset__legend">
+            <div className="govuk-accordion__section-header">
+              <h2 className="govuk-accordion__section-heading govuk-fieldset__heading">
+                <span
+                  className="govuk-accordion__section-button"
+                  id={`accordion-default-heading-${index + 1}`}
+                  data-cy={`cyAccordionButton-${''}`}
+                >
+                  Search options
+                </span>
+              </h2>
+            </div>
+          </legend>
+          <div
+            id={`accordion-default-content-${index + 1}`}
+            className="govuk-accordion__section-content"
+            data-testid="section-content"
+            aria-labelledby={`accordion-default-heading-${index + 1}`}
+            role="group"
+            data-cy={`cyAccordionContent-${''}`}
+          >
+            <Filters filters={filters} filterObj={filterObj} />
+          </div>
+        </fieldset>
+      </div>
+    </div>
+  );
+}
+
+function Filters({ filters, filterObj }) {
+  return (
+    <>
+      {filters?.map((filter, index) => (
+        <SearchFilterSelector
+          key={index}
+          index={index}
+          filter={filter}
+          filterObj={filterObj}
+        />
+      ))}
+
+      <SearchFilterDate index={filters.length} filterObj={filterObj} />
+    </>
   );
 }

--- a/styles/custom/gap-custom.scss
+++ b/styles/custom/gap-custom.scss
@@ -134,8 +134,15 @@ For custom accordion and filters page
   .govuk-accordion {
     border-bottom: 0;
   }
+
   .govuk-accordion__section--expanded .govuk-accordion__section-content {
     display: flex;
+  }
+
+  @media only screen and (max-width: 768px) {
+    .govuk-accordion__section--expanded .govuk-accordion__section-content {
+      display: block;
+    }
   }
 
   .gap_filters {


### PR DESCRIPTION
## Description

https://technologyprogramme.atlassian.net/browse/TMI2-550

Adds a new 'Search options' container for filter options when the search page is viewed on a mobile device. 

This container is collapsed when the page is initially loaded, allowing the user to scroll down to the grant listings much faster.

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
