### PR TITLE
Gap 2371

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,4 @@ ONE_LOGIN_ENABLED=true
 SESSION_COOKIE_NAME=session_id
 ADMIN_BACKEND_HOST=http:localhost:8081
 V2_LOGOUT_URL=http://localhost:8082/v2/logout
+APPLICANT_BACKEND_HOST=http://localhost:8080

--- a/__tests__/pages/apply/[pid].test.js
+++ b/__tests__/pages/apply/[pid].test.js
@@ -30,11 +30,9 @@ process.env.NEW_MANDATORY_QUESTION_JOURNEY_ENABLED = 'false';
 describe('getServerSideProps', () => {
   it('should return a redirect object with the expected destination when new mandatory question feature flag is off ', async () => {
     //this mocks getAdvertSchemeVersion()
-    axios.get.mockImplementation(() =>
-      Promise.resolve({
-        data: { schemeVersion: 2, internalApplication: true },
-      }),
-    );
+    axios.get.mockResolvedValue({
+      data: { schemeVersion: 2, internalApplication: true },
+    });
     process.env.APPLY_FOR_A_GRANT_APPLICANT_URL = 'applicantUrl';
     process.env.NEW_MANDATORY_QUESTION_JOURNEY_ENABLED = 'false';
 
@@ -51,11 +49,9 @@ describe('getServerSideProps', () => {
 
   it('should return a redirect object with the expected destination when new mandatory question feature flag is on ', async () => {
     //this mocks getAdvertSchemeVersion()
-    axios.get.mockImplementation(() =>
-      Promise.resolve({
-        data: { schemeVersion: 2, internalApplication: true },
-      }),
-    );
+    axios.get.mockResolvedValue({
+      data: { schemeVersion: 2, internalApplication: true },
+    });
     process.env.APPLY_FOR_A_GRANT_APPLICANT_URL = 'applicantUrl';
     process.env.NEW_MANDATORY_QUESTION_JOURNEY_ENABLED = 'true';
     const context = { params: { pid: 'your-path' } };

--- a/__tests__/pages/apply/[pid].test.js
+++ b/__tests__/pages/apply/[pid].test.js
@@ -1,35 +1,25 @@
-import {
-  getServerSideProps,
-  getAdvertSchemeVersion,
-} from '../../../pages/apply/[pid]'; // Import your module here
+import { getServerSideProps } from '../../../pages/apply/[pid]'; // Import your module here
+
+import * as axios from 'axios';
+
+// Mock out all top level functions, such as get, put, delete and post:
+jest.mock('axios');
 
 // Mock the fetchEntry function
 jest.mock('../../../src/utils/contentFulPage.ts', () => ({
   fetchEntry: jest.fn(() =>
     Promise.resolve({
       props: {
-        grantDetail: { fields: { grantWebpageUrl: 'https://example.com' } },
+        grantDetail: {
+          fields: {
+            grantWebpageUrl: 'https://example.com',
+            label: 'example-slug',
+          },
+        },
       },
     }),
   ),
 }));
-
-// Mock the getAdvertSchemeVersion function
-// jest.mock('../../../pages/apply/[pid]', () => ({
-//   getAdvertSchemeVersion: jest.fn(() =>
-//     Promise.resolve({
-//       data: {
-//         schemeVersion: 1,
-//         internalApplication: false,
-//       },
-//     }),
-//   ),
-// }));
-
-jest.mock('../../../pages/apply/[pid]', () => ({
-  getAdvertSchemeVersion: jest.fn(),
-}));
-const mockGetAdvertSchemeVersion = jest.mocked(getAdvertSchemeVersion);
 
 const applicantUrlBackup = process.env.APPLY_FOR_A_GRANT_APPLICANT_URL;
 const mandatoryQsEnabledBackup =
@@ -39,6 +29,12 @@ process.env.NEW_MANDATORY_QUESTION_JOURNEY_ENABLED = 'false';
 
 describe('getServerSideProps', () => {
   it('should return a redirect object with the expected destination when new mandatory question feature flag is off ', async () => {
+    //this mocks getAdvertSchemeVersion()
+    axios.get.mockImplementation(() =>
+      Promise.resolve({
+        data: { schemeVersion: 2, internalApplication: true },
+      }),
+    );
     process.env.APPLY_FOR_A_GRANT_APPLICANT_URL = 'applicantUrl';
     process.env.NEW_MANDATORY_QUESTION_JOURNEY_ENABLED = 'false';
 
@@ -54,23 +50,16 @@ describe('getServerSideProps', () => {
   });
 
   it('should return a redirect object with the expected destination when new mandatory question feature flag is on ', async () => {
-    mockGetAdvertSchemeVersion.mockResolvedValueOnce({
-      status: 200,
-      data: { schemeVersion: 2, internalApplication: true },
-    }),
-      (process.env.APPLY_FOR_A_GRANT_APPLICANT_URL = 'applicantUrl');
+    //this mocks getAdvertSchemeVersion()
+    axios.get.mockImplementation(() =>
+      Promise.resolve({
+        data: { schemeVersion: 2, internalApplication: true },
+      }),
+    );
+    process.env.APPLY_FOR_A_GRANT_APPLICANT_URL = 'applicantUrl';
     process.env.NEW_MANDATORY_QUESTION_JOURNEY_ENABLED = 'true';
     const context = { params: { pid: 'your-path' } };
     const result = await getServerSideProps(context);
-
-    // jest.mock('../../../pages/apply/[pid]', () => ({
-    //   getAdvertSchemeVersion: jest.fn(() =>
-    //     Promise.resolve({
-    //       status: 200,
-    //       data: { schemeVersion: 2, internalApplication: true },
-    //     }),
-    //   ),
-    // }));
 
     expect(result).toEqual({
       redirect: {

--- a/__tests__/pages/apply/[pid].test.js
+++ b/__tests__/pages/apply/[pid].test.js
@@ -12,7 +12,6 @@ jest.mock('../../../src/utils/contentFulPage.ts', () => ({
         grantDetail: {
           fields: {
             grantWebpageUrl: 'https://example.com',
-            label: 'example-slug',
           },
         },
       },

--- a/pages/apply/[pid].js
+++ b/pages/apply/[pid].js
@@ -33,9 +33,7 @@ export async function getServerSideProps({ params }) {
     child.info('button clicked');
   }
 
-  const advertSummary = await getAdvertSchemeVersion(
-    grantDetail.props.grantDetail.fields.label,
-  );
+  const advertSummary = await getAdvertSchemeVersion(grantDetail.fields.label);
 
   if (!advertSummary.data || advertSummary.response?.status === 404) {
     return {
@@ -52,8 +50,8 @@ export async function getServerSideProps({ params }) {
 
   const redirectUrl =
     newMandatoryQuestionsEnabled === 'true' && !isV1External
-      ? `${applicantUrl}/api/redirect-from-find?slug=${path}&grantWebpageUrl=${grantDetail.props.grantDetail.fields.grantWebpageUrl}`
-      : grantDetail.props.grantDetail.fields.grantWebpageUrl;
+      ? `${applicantUrl}/api/redirect-from-find?slug=${path}&grantWebpageUrl=${grantDetail.fields.grantWebpageUrl}`
+      : grantDetail.fields.grantWebpageUrl;
 
   return {
     props: {

--- a/pages/apply/[pid].js
+++ b/pages/apply/[pid].js
@@ -35,7 +35,7 @@ export async function getServerSideProps({ params }) {
     grantDetail.props.grantDetail.fields.label,
   );
 
-  if (!advertSummary.data || advertSummary.response.status === 404) {
+  if (!advertSummary.data || advertSummary.response?.status === 404) {
     return {
       redirect: {
         permanent: false,


### PR DESCRIPTION
## Description
This ticket modifies the login journey for V1 **external** grants, preventing a FIND user from having to login via One Login. Instead, a user is now instantly redirected to the external grant application URL.

GAP-2371: https://technologyprogramme.atlassian.net/browse/GAP-2371 

Summary of the changes and the related issue. List any dependencies that are required for this change:

## Type of change

Please check the relevant options.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [X] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
