### PR TITLE
restore client-side redirect on /apply/[pid]

### DIFF
--- a/__tests__/pages/apply/[pid].test.js
+++ b/__tests__/pages/apply/[pid].test.js
@@ -17,30 +17,46 @@ process.env.APPLY_FOR_A_GRANT_APPLICANT_URL = 'applicantUrl';
 process.env.NEW_MANDATORY_QUESTION_JOURNEY_ENABLED = 'false';
 
 describe('getServerSideProps', () => {
-  it('should return a redirect object with the expected destination when new mandatory question feature flag is off ', async () => {
+  it('should return a redirectUrl with the expected destination when new mandatory question feature flag is off ', async () => {
     process.env.APPLY_FOR_A_GRANT_APPLICANT_URL = 'applicantUrl';
     process.env.NEW_MANDATORY_QUESTION_JOURNEY_ENABLED = 'false';
     const context = { params: { pid: 'your-path' } };
     const result = await getServerSideProps(context);
 
     expect(result).toEqual({
-      redirect: {
-        permanent: false,
-        destination: 'https://example.com',
+      props: {
+        grantDetail: {
+          props: {
+            grantDetail: {
+              fields: {
+                grantWebpageUrl: 'https://example.com',
+              },
+            },
+          },
+        },
+        redirectUrl: 'https://example.com',
       },
     });
   });
 
-  it('should return a redirect object with the expected destination when new mandatory question feature flag is on ', async () => {
+  it('should return a redirectUrl with the expected destination when new mandatory question feature flag is on ', async () => {
     process.env.APPLY_FOR_A_GRANT_APPLICANT_URL = 'applicantUrl';
     process.env.NEW_MANDATORY_QUESTION_JOURNEY_ENABLED = 'true';
     const context = { params: { pid: 'your-path' } };
     const result = await getServerSideProps(context);
 
     expect(result).toEqual({
-      redirect: {
-        permanent: false,
-        destination:
+      props: {
+        grantDetail: {
+          props: {
+            grantDetail: {
+              fields: {
+                grantWebpageUrl: 'https://example.com',
+              },
+            },
+          },
+        },
+        redirectUrl:
           'applicantUrl/api/redirect-from-find?slug=your-path&grantWebpageUrl=https://example.com',
       },
     });

--- a/pages/apply/[pid].js
+++ b/pages/apply/[pid].js
@@ -55,6 +55,10 @@ const ApplyRedirect = (props) => {
         <title>
           {grant.grantName} - {gloss.title}
         </title>
+        {/* 
+          this meta element triggers a client-side redirect, which is required
+          for analytics reporting on this page
+        */}
         <meta
           httpEquiv="Refresh"
           content={'0; URL=' + grant.grantWebpageUrl}

--- a/pages/apply/[pid].js
+++ b/pages/apply/[pid].js
@@ -1,4 +1,6 @@
+import Head from 'next/head';
 import { fetchEntry } from '../../src/utils/contentFulPage';
+import gloss from '../../src/utils/glossary.json';
 
 const logger = require('pino')();
 
@@ -31,21 +33,35 @@ export async function getServerSideProps({ params }) {
     child.info('button clicked');
   }
 
-  const linkHref =
+  const redirectUrl =
     newMandatoryQuestionsEnabled === 'true'
       ? `${applicantUrl}/api/redirect-from-find?slug=${path}&grantWebpageUrl=${grantDetail.props.grantDetail.fields.grantWebpageUrl}`
       : grantDetail.props.grantDetail.fields.grantWebpageUrl;
 
   return {
-    redirect: {
-      permanent: false,
-      destination: linkHref,
+    props: {
+      redirectUrl,
+      grantDetail,
     },
   };
 }
 
-const ApplyRedirect = () => {
-  return <></>;
+const ApplyRedirect = (props) => {
+  const grant = props.grantDetail.fields;
+
+  return (
+    <>
+      <Head>
+        <title>
+          {grant.grantName} - {gloss.title}
+        </title>
+        <meta
+          httpEquiv="Refresh"
+          content={'0; URL=' + grant.grantWebpageUrl}
+        ></meta>
+      </Head>
+    </>
+  );
 };
 
 export default ApplyRedirect;


### PR DESCRIPTION
## Description

Fixes analytics no longer being reported from /apply/[pid] by restoring the client-side redirect, so that the analytics script will load on the client and report the page visit.

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

Please attach screenshots of the change if it is a UI change:

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
