### PR TITLE
Fixing select input

### DIFF
--- a/src/components/input-select/SelectInputLib.js
+++ b/src/components/input-select/SelectInputLib.js
@@ -414,4 +414,5 @@ function initialize($el, options, onChange, initialValue) {
   new Select($el, options, onChange, initialValue);
 }
 
-exports.Select = initialize;
+const _Select = initialize;
+export { _Select as Select };


### PR DESCRIPTION
After removing babel & replacing with SWC - got an error related to this component due to `exports is not defined`. Tested locally and this resolved the error