### PR TITLE
TMI2-701 - Filter buttons have no padding

### DIFF
--- a/src/components/search-page/search-filter-container/SearchFilterContainer.js
+++ b/src/components/search-page/search-filter-container/SearchFilterContainer.js
@@ -72,7 +72,7 @@ function SearchButtons({ filterObj, query }) {
   return (
     <>
       {' '}
-      <div className="govuk-button-group govuk-!-margin-bottom-0 gap_filters-actions">
+      <div className="govuk-button-group govuk-!-margin-top-5 govuk-!-margin-bottom-0 gap_filters-actions">
         <SearchFilterButton />
 
         <SearchFilterClearButton


### PR DESCRIPTION
## Description

Ticket # and link

[[Find] Filters buttons have no padding above them](https://technologyprogramme.atlassian.net/browse/TMI2-701)

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [ ] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

<img width="986" alt="Screenshot 2024-03-01 at 15 00 25" src="https://github.com/cabinetoffice/gap-find-web/assets/107405237/a45d924a-9686-43b6-93a5-c75783958e13">

# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
