### PR TITLE
TMI2-703 - Fix for ambiguous 'midnight' times

### DIFF
--- a/__tests__/components/grant-details/grant-details-header.test.js
+++ b/__tests__/components/grant-details/grant-details-header.test.js
@@ -25,6 +25,20 @@ describe('GrantDetailsHeader component', () => {
     expect(screen.getByText('15 April 2022, 9:34am')).toBeDefined();
   });
 
+  it('should render an altered opening and closing date on the screen for midnight times', () => {
+    const grantWithMidnightDates = {
+      ...grant,
+      grantApplicationOpenDate: '2022-04-07T00:00:00.000+00',
+      grantApplicationCloseDate: '2022-04-15T00:00:00.000+00',
+    };
+    const componentWithMidnightDates = (
+      <GrantDetailsHeader grant={grantWithMidnightDates} />
+    );
+    render(componentWithMidnightDates);
+    expect(screen.getByText('7 April 2022, 12:01am')).toBeDefined();
+    expect(screen.getByText('14 April 2022, 11:59pm')).toBeDefined();
+  });
+
   it('should render the values from glossary.json for the opening and closing dates', () => {
     expect(screen.getByText('Closing date:')).toBeDefined();
     expect(screen.getByText('Opening date:')).toBeDefined();

--- a/__tests__/components/searchpage/search-result-card.test.js
+++ b/__tests__/components/searchpage/search-result-card.test.js
@@ -76,6 +76,20 @@ describe('SearchResultCard', () => {
     expect(screen.queryByText(item.grantApplicantType[0])).toBeNull();
   });
 
+  it('should render an altered opening and closing date on the screen for midnight times', () => {
+    const itemWithMidnightDates = {
+      ...item,
+      grantApplicationOpenDate: '2022-04-21T00:00:00.000+00',
+      grantApplicationCloseDate: '2022-05-21T00:00:00.000+00',
+    };
+    const componentWithMidnightDates = (
+      <SearchResultCard item={itemWithMidnightDates} />
+    );
+    render(componentWithMidnightDates);
+    expect(screen.getByText('21 April 2022, 12:01am')).toBeDefined();
+    expect(screen.getByText('20 May 2022, 11:59pm')).toBeDefined();
+  });
+
   it('should render hr at the bottom of the list item', () => {
     render(component);
     expect(screen.getByRole('separator')).toBeDefined();

--- a/__tests__/utils/adjustDateTimes.test.js
+++ b/__tests__/utils/adjustDateTimes.test.js
@@ -1,0 +1,26 @@
+import { adjustDateTimes } from '../../src/utils/adjustDateTimes';
+
+describe('For removing ambiguity with opening and closing times when they are set to midnight', () => {
+  it('should return an object with changed timestamps when input times are set to midnight', () => {
+    const inputOpenDate = '2022-02-07 00:00:00.000+00';
+    const inputCloseDate = '2022-04-07 00:00:00.000+00';
+
+    const expectedOpenDate = '2022-02-07 00:01:00.000+00';
+    const expectedCloseDate = '2022-04-06 23:59:00.000+00';
+
+    const result = adjustDateTimes(inputOpenDate, inputCloseDate);
+
+    expect(result.adjustedOpenDate.isSame(expectedOpenDate)).toBe(true);
+    expect(result.adjustedCloseDate.isSame(expectedCloseDate)).toBe(true);
+  });
+
+  it('should return an object with unchanged timestamps when input times are not set to midnight', () => {
+    const inputOpenDate = '2022-02-07 01:45:00.000+00';
+    const inputCloseDate = '2022-04-07 23:27:00.000+00';
+
+    const result = adjustDateTimes(inputOpenDate, inputCloseDate);
+
+    expect(result.adjustedOpenDate.isSame(inputOpenDate)).toBe(true);
+    expect(result.adjustedCloseDate.isSame(inputCloseDate)).toBe(true);
+  });
+});

--- a/src/components/grant-details-page/grant-details-header/GrantDetailsHeader.js
+++ b/src/components/grant-details-page/grant-details-header/GrantDetailsHeader.js
@@ -2,8 +2,14 @@ import 'moment-timezone';
 import Moment from 'react-moment';
 import gloss from '../../../utils/glossary.json';
 import moment from 'moment';
+import { adjustDateTimes } from '../../../utils/adjustDateTimes';
 
 export function GrantDetailsHeader({ grant }) {
+  const { adjustedOpenDate, adjustedCloseDate } = adjustDateTimes(
+    grant.grantApplicationOpenDate,
+    grant.grantApplicationCloseDate,
+  );
+
   return (
     <div className="govuk-grid-column-three-quarters">
       <h1
@@ -20,7 +26,7 @@ export function GrantDetailsHeader({ grant }) {
           <strong>{gloss.grantDetails.opens}:</strong>{' '}
           <span>
             <Moment format="D MMMM YYYY, h:mma" tz="GMT">
-              {moment.utc(grant.grantApplicationOpenDate)}
+              {moment.utc(adjustedOpenDate)}
             </Moment>
           </span>
         </li>
@@ -28,7 +34,7 @@ export function GrantDetailsHeader({ grant }) {
           <strong>{gloss.grantDetails.closes}:</strong>{' '}
           <span>
             <Moment format="D MMMM YYYY, h:mma" tz="GMT">
-              {moment.utc(grant.grantApplicationCloseDate)}
+              {moment.utc(adjustedCloseDate)}
             </Moment>
           </span>
         </li>

--- a/src/components/search-page/search-result-card/SearchResultCard.js
+++ b/src/components/search-page/search-result-card/SearchResultCard.js
@@ -2,9 +2,13 @@ import 'moment-timezone';
 import Link from 'next/link';
 import Moment from 'react-moment';
 import gloss from '../../../utils/glossary.json';
-import moment from 'moment';
+import { adjustDateTimes } from '../../../utils/adjustDateTimes';
 
 export function SearchResultCard({ item }) {
+  const { adjustedOpenDate, adjustedCloseDate } = adjustDateTimes(
+    item.grantApplicationOpenDate,
+    item.grantApplicationCloseDate,
+  );
   return (
     <li id={item.label}>
       <h2 className="govuk-heading-m">
@@ -60,7 +64,7 @@ export function SearchResultCard({ item }) {
           {gloss.browse.opens + ' '}
         </span>
         <Moment format="D MMMM YYYY, h:mma" tz="GMT">
-          {moment.utc(item.grantApplicationOpenDate)}
+          {adjustedOpenDate}
         </Moment>
       </p>
       <p className="govuk-body govuk-!-margin-bottom-5">
@@ -68,7 +72,7 @@ export function SearchResultCard({ item }) {
           {gloss.browse.closes + ' '}
         </span>
         <Moment format="D MMMM YYYY, h:mma" tz="GMT">
-          {moment.utc(item.grantApplicationCloseDate)}
+          {adjustedCloseDate}
         </Moment>
       </p>
       <div className="govuk-!-margin-bottom-5">

--- a/src/utils/adjustDateTimes.js
+++ b/src/utils/adjustDateTimes.js
@@ -1,0 +1,17 @@
+import moment from 'moment';
+
+// Adjusts opening and closing date times to be 12:01am and 11:59pm respectively to avoid ambiguity around 'midnight' times
+
+export function adjustDateTimes(openDate, closeDate) {
+  const adjustedOpenDate = moment.utc(openDate).startOf('day');
+  const adjustedCloseDate = moment.utc(closeDate).startOf('day');
+
+  return {
+    adjustedOpenDate: adjustedOpenDate.isSame(moment.utc(openDate))
+      ? adjustedOpenDate.add(1, 'minute')
+      : moment.utc(openDate),
+    adjustedCloseDate: adjustedCloseDate.isSame(moment.utc(closeDate))
+      ? adjustedCloseDate.subtract(1, 'minute')
+      : moment.utc(closeDate),
+  };
+}


### PR DESCRIPTION
## Description

Ticket # and link

[Ambiguous times around midnight](https://technologyprogramme.atlassian.net/browse/TMI2-703)

Adds logic to alter 'midnight' to display as 12:01am for the opening date and 11:59pm of the day before the closing date to remove ambiguity from displaying '12:00am' for midnight. **The opening date format is a change from the AC on the ticket and has been approved by Zoe.**

## Type of change

Please check the relevant options.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):

<img width="1376" alt="Screenshot 2024-03-05 at 12 24 25" src="https://github.com/cabinetoffice/gap-find-web/assets/107405237/51ef90e7-2a4b-4348-b7c0-046ab30f4558">
<img width="1229" alt="Screenshot 2024-03-05 at 12 24 59" src="https://github.com/cabinetoffice/gap-find-web/assets/107405237/97781f07-3777-44e3-a77c-469154f703b7">


# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.
