### PR TITLE
GAP-2543-opening-closing-times

### DIFF
--- a/__tests__/components/grant-details/grant-details-header.test.js
+++ b/__tests__/components/grant-details/grant-details-header.test.js
@@ -11,21 +11,21 @@ const grant = {
 const component = <GrantDetailsHeader grant={grant} />;
 
 describe('GrantDetailsHeader component', () => {
-  beforeEach(() => {
-    render(component);
-  });
   it('should render a header with all the correct attributes set by the component', () => {
+    render(component);
     const header = screen.getByRole('heading', { name: 'test' });
     expect(header).toBeDefined();
     expect(header.getAttribute('tabindex')).toBe('-1');
   });
 
   it('should render an opening and closing date on the screen', () => {
+    render(component);
     expect(screen.getByText('7 April 2022, 9:34am')).toBeDefined();
     expect(screen.getByText('15 April 2022, 9:34am')).toBeDefined();
   });
 
   it('should render an altered opening and closing date on the screen for midnight times', () => {
+    render(component);
     const grantWithMidnightDates = {
       ...grant,
       grantApplicationOpenDate: '2022-04-07T00:00:00.000+00',
@@ -35,16 +35,43 @@ describe('GrantDetailsHeader component', () => {
       <GrantDetailsHeader grant={grantWithMidnightDates} />
     );
     render(componentWithMidnightDates);
-    expect(screen.getByText('7 April 2022, 12:01am')).toBeDefined();
-    expect(screen.getByText('14 April 2022, 11:59pm')).toBeDefined();
+    const openingDate = screen.getByText('7 April 2022, 12:01am');
+    expect(openingDate).toBeDefined();
+    expect(openingDate.parentElement.textContent).toContain('(Midnight)');
+
+    const closingDate = screen.getByText('14 April 2022, 11:59pm');
+    expect(closingDate).toBeDefined();
+    expect(closingDate.parentElement.textContent).toContain('(Midnight)');
+  });
+
+  it('should render an altered opening and closing date on the screen for midday times', () => {
+    render(component);
+    const grantWithMidnightDates = {
+      ...grant,
+      grantApplicationOpenDate: '2022-04-07T12:00:00.000+00',
+      grantApplicationCloseDate: '2022-04-15T12:00:00.000+00',
+    };
+    const componentWithMidnightDates = (
+      <GrantDetailsHeader grant={grantWithMidnightDates} />
+    );
+    render(componentWithMidnightDates);
+    const openingDate = screen.getByText('7 April 2022, 12:00pm');
+    expect(openingDate).toBeDefined();
+    expect(openingDate.parentElement.textContent).toContain('(Midday)');
+
+    const closingDate = screen.getByText('15 April 2022, 12:00pm');
+    expect(closingDate).toBeDefined();
+    expect(closingDate.parentElement.textContent).toContain('(Midday)');
   });
 
   it('should render the values from glossary.json for the opening and closing dates', () => {
+    render(component);
     expect(screen.getByText('Closing date:')).toBeDefined();
     expect(screen.getByText('Opening date:')).toBeDefined();
   });
 
   it('should Render the shortDescription', () => {
+    render(component);
     screen.getByText('Short Description');
   });
 });

--- a/__tests__/components/grant-details/grant-details-header.test.js
+++ b/__tests__/components/grant-details/grant-details-header.test.js
@@ -11,21 +11,22 @@ const grant = {
 const component = <GrantDetailsHeader grant={grant} />;
 
 describe('GrantDetailsHeader component', () => {
-  it('should render a header with all the correct attributes set by the component', () => {
+  beforeEach(() => {
     render(component);
+  });
+
+  it('should render a header with all the correct attributes set by the component', () => {
     const header = screen.getByRole('heading', { name: 'test' });
     expect(header).toBeDefined();
     expect(header.getAttribute('tabindex')).toBe('-1');
   });
 
   it('should render an opening and closing date on the screen', () => {
-    render(component);
     expect(screen.getByText('7 April 2022, 9:34am')).toBeDefined();
     expect(screen.getByText('15 April 2022, 9:34am')).toBeDefined();
   });
 
   it('should render an altered opening and closing date on the screen for midnight times', () => {
-    render(component);
     const grantWithMidnightDates = {
       ...grant,
       grantApplicationOpenDate: '2022-04-07T00:00:00.000+00',
@@ -45,7 +46,6 @@ describe('GrantDetailsHeader component', () => {
   });
 
   it('should render an altered opening and closing date on the screen for midday times', () => {
-    render(component);
     const grantWithMidnightDates = {
       ...grant,
       grantApplicationOpenDate: '2022-04-07T12:00:00.000+00',
@@ -65,13 +65,11 @@ describe('GrantDetailsHeader component', () => {
   });
 
   it('should render the values from glossary.json for the opening and closing dates', () => {
-    render(component);
     expect(screen.getByText('Closing date:')).toBeDefined();
     expect(screen.getByText('Opening date:')).toBeDefined();
   });
 
   it('should Render the shortDescription', () => {
-    render(component);
     screen.getByText('Short Description');
   });
 });

--- a/__tests__/pages/grant-page.test.js
+++ b/__tests__/pages/grant-page.test.js
@@ -28,8 +28,8 @@ const mockGrant = {
   grantMinimumAwardDisplay: '£500',
   grantMaximumAwardDisplay: '£10,000',
   grantTotalAwardDisplay: '£100 million',
-  grantApplicationOpenDate: '2022-02-03T00:01+00:00',
-  grantApplicationCloseDate: '2022-04-03T00:01+00:00',
+  grantApplicationOpenDate: '2022-02-03T00:02+00:00',
+  grantApplicationCloseDate: '2022-04-03T00:02+00:00',
 };
 
 const mockFilters = [
@@ -73,6 +73,44 @@ const component = (
 const invalidFilterComponent = (
   <BrowseGrants
     searchResult={[mockGrant]}
+    searchTerm="search"
+    searchHeading="Search grants"
+    filters={mockFilters}
+    errors={[{ field: 'datepicker', error: 'Test' }]}
+    filterObj={{ errors: [{ field: 'datepicker', error: 'Test' }] }}
+    totalGrants={1}
+    query={{}}
+  />
+);
+
+const midnightGrantComponent = (
+  <BrowseGrants
+    searchResult={[
+      {
+        ...mockGrant,
+        grantApplicationOpenDate: '2022-02-03T00:00+00:00',
+        grantApplicationCloseDate: '2022-04-03T00:00+00:00',
+      },
+    ]}
+    searchTerm="search"
+    searchHeading="Search grants"
+    filters={mockFilters}
+    errors={[{ field: 'datepicker', error: 'Test' }]}
+    filterObj={{ errors: [{ field: 'datepicker', error: 'Test' }] }}
+    totalGrants={1}
+    query={{}}
+  />
+);
+
+const middayGrantComponent = (
+  <BrowseGrants
+    searchResult={[
+      {
+        ...mockGrant,
+        grantApplicationOpenDate: '2022-02-03T12:00+00:00',
+        grantApplicationCloseDate: '2022-04-03T12:00+00:00',
+      },
+    ]}
     searchTerm="search"
     searchHeading="Search grants"
     filters={mockFilters}
@@ -171,7 +209,7 @@ describe('Rendering the browse grants page', () => {
     expect(screen.getByText('£100 million')).toBeDefined();
   });
 
-  it('Should render grant opening date', () => {
+  it('Should render grant opening date without a suffix', () => {
     renderWithRouter(component);
     expect(
       screen.getByText((content, element) => {
@@ -180,10 +218,10 @@ describe('Rendering the browse grants page', () => {
         );
       }),
     ).toBeDefined();
-    expect(screen.getByText('3 February 2022, 12:01am')).toBeDefined();
+    expect(screen.getByText('3 February 2022, 12:02am')).toBeDefined();
   });
 
-  it('Should render grant closing date', () => {
+  it('Should render grant closing date without a suffix', () => {
     renderWithRouter(component);
     expect(
       screen.getByText((content, element) => {
@@ -192,7 +230,63 @@ describe('Rendering the browse grants page', () => {
         );
       }),
     ).toBeDefined();
-    expect(screen.getByText('3 April 2022, 12:01am')).toBeDefined();
+    expect(screen.getByText('3 April 2022, 12:02am')).toBeDefined();
+  });
+
+  it('Should render grant opening date with (Midnight)', () => {
+    renderWithRouter(midnightGrantComponent);
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element.tagName.toLowerCase() === 'dt' && content === 'Opening date'
+        );
+      }),
+    ).toBeDefined();
+    const date = screen.getByText('3 February 2022, 12:01am');
+    expect(date).toBeDefined();
+    expect(date.parentElement.textContent).toContain('(Midnight)');
+  });
+
+  it('Should render grant closing date with (Midnight)', () => {
+    renderWithRouter(midnightGrantComponent);
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element.tagName.toLowerCase() === 'dt' && content === 'Closing date'
+        );
+      }),
+    ).toBeDefined();
+    const date = screen.getByText('2 April 2022, 11:59pm');
+    expect(date).toBeDefined();
+    expect(date.parentElement.textContent).toContain('(Midnight)');
+  });
+
+  it('Should render grant opening date with (Midday)', () => {
+    renderWithRouter(middayGrantComponent);
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element.tagName.toLowerCase() === 'dt' && content === 'Opening date'
+        );
+      }),
+    ).toBeDefined();
+    const date = screen.getByText('3 February 2022, 12:00pm');
+    expect(date).toBeDefined();
+    expect(date.parentElement.textContent).toContain('(Midday)');
+  });
+
+  it('Should render grant closing date with (Midday)', () => {
+    renderWithRouter(middayGrantComponent);
+    expect(
+      screen.getByText((content, element) => {
+        return (
+          element.tagName.toLowerCase() === 'dt' && content === 'Closing date'
+        );
+      }),
+    ).toBeDefined();
+    const date = screen.getByText('3 April 2022, 12:00pm');
+    expect(date).toBeDefined();
+    expect(date.parentElement.textContent).toContain('(Midday)');
   });
 
   it('Should render a label for the search form', () => {

--- a/src/components/grant-details-page/grant-details-header/GrantDetailsHeader.js
+++ b/src/components/grant-details-page/grant-details-header/GrantDetailsHeader.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 import { adjustDateTimes } from '../../../utils/adjustDateTimes';
 
 export function GrantDetailsHeader({ grant }) {
-  const { adjustedOpenDate, adjustedCloseDate } = adjustDateTimes(
+  const { adjustedOpenDate, adjustedCloseDate, timeSuffixes } = adjustDateTimes(
     grant.grantApplicationOpenDate,
     grant.grantApplicationCloseDate,
   );
@@ -28,6 +28,7 @@ export function GrantDetailsHeader({ grant }) {
             <Moment format="D MMMM YYYY, h:mma" tz="GMT">
               {moment.utc(adjustedOpenDate)}
             </Moment>
+            {timeSuffixes.open}
           </span>
         </li>
         <li>
@@ -36,6 +37,7 @@ export function GrantDetailsHeader({ grant }) {
             <Moment format="D MMMM YYYY, h:mma" tz="GMT">
               {moment.utc(adjustedCloseDate)}
             </Moment>
+            {timeSuffixes.close}
           </span>
         </li>
       </ul>

--- a/src/components/search-page/search-result-card/SearchResultCard.js
+++ b/src/components/search-page/search-result-card/SearchResultCard.js
@@ -5,7 +5,7 @@ import gloss from '../../../utils/glossary.json';
 import { adjustDateTimes } from '../../../utils/adjustDateTimes';
 
 export function SearchResultCard({ item }) {
-  const { adjustedOpenDate, adjustedCloseDate } = adjustDateTimes(
+  const { adjustedOpenDate, adjustedCloseDate, timeSuffixes } = adjustDateTimes(
     item.grantApplicationOpenDate,
     item.grantApplicationCloseDate,
   );
@@ -69,6 +69,7 @@ export function SearchResultCard({ item }) {
             <Moment format="D MMMM YYYY, h:mma" tz="GMT">
               {adjustedOpenDate}
             </Moment>
+            {timeSuffixes.open}
           </dd>
         </div>
         <div className="govuk-summary-list__row govuk-summary-list__row--no-actions">
@@ -77,6 +78,7 @@ export function SearchResultCard({ item }) {
             <Moment format="D MMMM YYYY, h:mma" tz="GMT">
               {adjustedCloseDate}
             </Moment>
+            {timeSuffixes.close}
           </dd>
         </div>
       </dl>

--- a/src/utils/adjustDateTimes.js
+++ b/src/utils/adjustDateTimes.js
@@ -3,6 +3,11 @@ import moment from 'moment';
 // Adjusts opening and closing date times to be 12:01am and 11:59pm respectively to avoid ambiguity around 'midnight' times
 
 export function adjustDateTimes(openDate, closeDate) {
+  const timeSuffixes = {
+    open: getTimeSuffix(openDate),
+    close: getTimeSuffix(closeDate),
+  };
+
   const adjustedOpenDate = moment.utc(openDate).startOf('day');
   const adjustedCloseDate = moment.utc(closeDate).startOf('day');
 
@@ -13,5 +18,18 @@ export function adjustDateTimes(openDate, closeDate) {
     adjustedCloseDate: adjustedCloseDate.isSame(moment.utc(closeDate))
       ? adjustedCloseDate.subtract(1, 'minute')
       : moment.utc(closeDate),
+    timeSuffixes,
   };
+}
+
+function getTimeSuffix(date) {
+  if (
+    moment.utc(date).format('HH:mm') === '23:59' ||
+    moment.utc(date).format('HH:mm') === '00:00' ||
+    moment.utc(date).format('HH:mm') === '00:01'
+  ) {
+    return ' (Midnight)';
+  } else if (moment.utc(date).format('HH:mm') === '12:00') {
+    return ' (Midday)';
+  } else return '';
 }

--- a/src/utils/adjustDateTimes.js
+++ b/src/utils/adjustDateTimes.js
@@ -23,13 +23,14 @@ export function adjustDateTimes(openDate, closeDate) {
 }
 
 function getTimeSuffix(date) {
-  if (
-    moment.utc(date).format('HH:mm') === '23:59' ||
-    moment.utc(date).format('HH:mm') === '00:00' ||
-    moment.utc(date).format('HH:mm') === '00:01'
-  ) {
-    return ' (Midnight)';
-  } else if (moment.utc(date).format('HH:mm') === '12:00') {
-    return ' (Midday)';
-  } else return '';
+  switch (moment.utc(date).format('HH:mm')) {
+    case '23:59':
+    case '00:00':
+    case '00:01':
+      return ' (Midnight)';
+    case '12:00':
+      return ' (Midday)';
+    default:
+      return '';
+  }
 }


### PR DESCRIPTION
## Description

[GAP-2543](https://technologyprogramme.atlassian.net/browse/GAP-2543?atlOrigin=eyJpIjoiNmQwNmUyZmQzNmNjNDUyZGJmMGQzZGVhNzViOGJkMDMiLCJwIjoiaiJ9)

As per the ticket, this change involves adding suffixes to the end of times at Midnight and Midday as per GDS guidelines. To achieve this, this change updates adjustDateTimes.js to determine what suffix (if any) is required and returns it. The SearchResultCard.js and GrantDetailsHeader.js components have also been updated to accommodate this and display the new time suffixes.

## Type of change

Please check the relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] This change requires a documentation update.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes:

- [x] Unit Test

- [ ] Integration Test (if applicable)

- [ ] End to End Test (if applicable)

## Screenshots (if appropriate):
<img width="1840" alt="Screenshot 2024-04-16 at 14 24 15" src="https://github.com/cabinetoffice/gap-find-web/assets/127317407/a33a8766-c2c3-4608-92e8-e6b660d792d5">
<img width="1840" alt="Screenshot 2024-04-16 at 14 24 36" src="https://github.com/cabinetoffice/gap-find-web/assets/127317407/5a964395-f439-454e-9d81-2f65570e85c7">


# Checklist:

- [ ] If I have listed dependencies above, I have ensured that they are present in the target branch.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation where applicable.
- [ ] I have ran cypress tests and they all pass locally.


[GAP-2543]: https://technologyprogramme.atlassian.net/browse/GAP-2543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ